### PR TITLE
If an origin was passed in, don't change it

### DIFF
--- a/lib/Protocol/WebSocket/Response.pm
+++ b/lib/Protocol/WebSocket/Response.pm
@@ -63,7 +63,7 @@ sub headers {
         resource_name => $self->resource_name,
     );
     my $origin = $self->origin ? $self->origin : 'http://' . $location->host;
-    $origin =~ s{^http:}{https:} if $self->secure;
+    $origin =~ s{^http:}{https:} if !$self->origin && $self->secure;
 
     if ($self->version <= 75) {
         push @$headers, 'WebSocket-Protocol' => $self->subprotocol


### PR DESCRIPTION
The use case I have for this is the origin is http, but the websocket was
established as wss.  I manually set secure=1 on the response, but that was
also changing the http to https on the origin.
