### PR TITLE
Include PSGI QUERY_STRING in the resource_name

### DIFF
--- a/lib/Protocol/WebSocket/Request.pm
+++ b/lib/Protocol/WebSocket/Request.pm
@@ -38,7 +38,8 @@ sub new_from_psgi {
 
     my $self = $class->new(
         fields        => $fields,
-        resource_name => "$env->{SCRIPT_NAME}$env->{PATH_INFO}"
+        resource_name => "$env->{SCRIPT_NAME}$env->{PATH_INFO}".
+                         ($env->{QUERY_STRING} ? "?$env->{QUERY_STRING}" : "")
     );
     $self->state('body');
 


### PR DESCRIPTION
This will append the QUERY_STRING the the resource_name in `Protocol::WebSocket::Request->new_from_psgi`. This avoids a Location mismatch in the response.
