### PR TITLE
Check $self->origin and set $self->secure(1) only if $self->origin is present in Request.pm

### DIFF
--- a/lib/Protocol/WebSocket/Request.pm
+++ b/lib/Protocol/WebSocket/Request.pm
@@ -372,7 +372,9 @@ sub _finalize {
     #return unless $origin;
     $self->origin($origin);
 
-    $self->secure(1) if $self->origin =~ m{^https:};
+    if (defined $self->origin) {
+        $self->secure(1) if $self->origin =~ m{^https:};
+    }
 
     my $host = $self->field('Host');
     return unless $host;


### PR DESCRIPTION
Solve the issue of 
Use of uninitialized value in pattern match (m//) at /.../Protocol/WebSocket/Request.pm line 375, <> line 14.
