### PR TITLE
implemented set cookies for requests

### DIFF
--- a/t/draft-ietf-hybi-00/client-ssl.t
+++ b/t/draft-ietf-hybi-00/client-ssl.t
@@ -16,11 +16,13 @@ $h->url('wss://example.com/demo');
 $h->req->key1("18x 6]8vM;54 *(5:  {   U1]8  z [  8");
 $h->req->key2("1_ tx7X d  <  nw  334J702) 7]o}` 0");
 $h->req->challenge("Tm[K T2u");
+$h->req->cookies('foo=bar; alice=bob');
 
 is $h->to_string => "GET /demo HTTP/1.1\x0d\x0a"
   . "Upgrade: WebSocket\x0d\x0a"
   . "Connection: Upgrade\x0d\x0a"
   . "Host: example.com\x0d\x0a"
+  . "Cookie: foo=bar; alice=bob\x0d\x0a"
   . "Origin: https://example.com\x0d\x0a"
   . "Sec-WebSocket-Key1: 18x 6]8vM;54 *(5:  {   U1]8  z [  8\x0d\x0a"
   . "Sec-WebSocket-Key2: 1_ tx7X d  <  nw  334J702) 7]o}` 0\x0d\x0a"

--- a/t/draft-ietf-hybi-00/client.t
+++ b/t/draft-ietf-hybi-00/client.t
@@ -16,11 +16,13 @@ $h->url('ws://example.com/demo');
 $h->req->key1("18x 6]8vM;54 *(5:  {   U1]8  z [  8");
 $h->req->key2("1_ tx7X d  <  nw  334J702) 7]o}` 0");
 $h->req->challenge("Tm[K T2u");
+$h->req->cookies('foo=bar; alice=bob');
 
 is $h->to_string => "GET /demo HTTP/1.1\x0d\x0a"
   . "Upgrade: WebSocket\x0d\x0a"
   . "Connection: Upgrade\x0d\x0a"
   . "Host: example.com\x0d\x0a"
+  . "Cookie: foo=bar; alice=bob\x0d\x0a"
   . "Origin: http://example.com\x0d\x0a"
   . "Sec-WebSocket-Key1: 18x 6]8vM;54 *(5:  {   U1]8  z [  8\x0d\x0a"
   . "Sec-WebSocket-Key2: 1_ tx7X d  <  nw  334J702) 7]o}` 0\x0d\x0a"

--- a/t/draft-ietf-hybi-10/client.t
+++ b/t/draft-ietf-hybi-10/client.t
@@ -12,11 +12,13 @@ $h->url('ws://example.com/demo');
 
 # Mocking
 $h->req->key("dGhlIHNhbXBsZSBub25jZQ==");
+$h->req->cookies('foo=bar; alice=bob');
 
 is $h->to_string => "GET /demo HTTP/1.1\x0d\x0a"
   . "Upgrade: WebSocket\x0d\x0a"
   . "Connection: Upgrade\x0d\x0a"
   . "Host: example.com\x0d\x0a"
+  . "Cookie: foo=bar; alice=bob\x0d\x0a"
   . "Sec-WebSocket-Origin: http://example.com\x0d\x0a"
   . "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\x0d\x0a"
   . "Sec-WebSocket-Version: 8\x0d\x0a"

--- a/t/draft-ietf-hybi-17/client.t
+++ b/t/draft-ietf-hybi-17/client.t
@@ -12,11 +12,13 @@ $h->url('ws://example.com/demo');
 
 # Mocking
 $h->req->key("dGhlIHNhbXBsZSBub25jZQ==");
+$h->req->cookies('foo=bar; alice=bob');
 
 is $h->to_string => "GET /demo HTTP/1.1\x0d\x0a"
   . "Upgrade: WebSocket\x0d\x0a"
   . "Connection: Upgrade\x0d\x0a"
   . "Host: example.com\x0d\x0a"
+  . "Cookie: foo=bar; alice=bob\x0d\x0a"
   . "Origin: http://example.com\x0d\x0a"
   . "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\x0d\x0a"
   . "Sec-WebSocket-Version: 13\x0d\x0a"

--- a/t/draft-ietf-hybi-17/request.t
+++ b/t/draft-ietf-hybi-17/request.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 54;
+use Test::More tests => 57;
 
 use_ok 'Protocol::WebSocket::Request';
 
@@ -19,6 +19,8 @@ is $req->state => 'fields';
 
 ok $req->parse("Host: server.example.com\x0d\x0a");
 is $req->state => 'fields';
+ok $req->parse("Cookie: foo=bar;alice=bob\x0d\x0a");
+is $req->state => 'fields';
 ok $req->parse("Upgrade: websocket\x0d\x0a");
 is $req->state => 'fields';
 ok $req->parse("Connection: Upgrade\x0d\x0a");
@@ -30,11 +32,12 @@ ok $req->parse("Sec-WebSocket-Version: 13\x0d\x0a\x0d\x0a");
 is $req->state => 'done';
 is $req->key   => 'dGhlIHNhbXBsZSBub25jZQ==';
 
-is $req->version       => 'draft-ietf-hybi-17';
-is $req->subprotocol   => 'chat, superchat';
-is $req->resource_name => '/chat';
-is $req->host          => 'server.example.com';
-is $req->origin        => 'http://example.com';
+is $req->version            => 'draft-ietf-hybi-17';
+is $req->subprotocol        => 'chat, superchat';
+is $req->resource_name      => '/chat';
+is $req->host               => 'server.example.com';
+is $req->origin             => 'http://example.com';
+is $req->cookies->to_string => 'foo=bar; alice=bob';
 
 $req = Protocol::WebSocket::Request->new;
 
@@ -75,6 +78,7 @@ is $req->origin        => 'http://example.com';
 $req = Protocol::WebSocket::Request->new(
     host          => 'server.example.com',
     origin        => 'http://example.com',
+    cookies       => Protocol::WebSocket::Cookie->new->parse('foo=bar; alice=bob'),
     subprotocol   => 'chat, superchat',
     resource_name => '/chat',
     key           => 'dGhlIHNhbXBsZSBub25jZQ=='
@@ -83,6 +87,7 @@ is $req->to_string => "GET /chat HTTP/1.1\x0d\x0a"
   . "Upgrade: WebSocket\x0d\x0a"
   . "Connection: Upgrade\x0d\x0a"
   . "Host: server.example.com\x0d\x0a"
+  . "Cookie: foo=bar; alice=bob\x0d\x0a"
   . "Origin: http://example.com\x0d\x0a"
   . "Sec-WebSocket-Protocol: chat, superchat\x0d\x0a"
   . "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\x0d\x0a"

--- a/t/draft-ietf-hybi-17/request_psgi.t
+++ b/t/draft-ietf-hybi-17/request_psgi.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 10;
+use Test::More tests => 11;
 
 use IO::Handle;
 
@@ -23,6 +23,7 @@ $req = Protocol::WebSocket::Request->new_from_psgi(
         HTTP_UPGRADE                => 'websocket',
         HTTP_CONNECTION             => 'Upgrade',
         HTTP_HOST                   => 'server.example.com',
+        HTTP_COOKIE                 => 'foo=bar',
         HTTP_SEC_WEBSOCKET_ORIGIN   => 'http://example.com',
         HTTP_SEC_WEBSOCKET_PROTOCOL => 'chat, superchat',
         HTTP_SEC_WEBSOCKET_KEY      => 'dGhlIHNhbXBsZSBub25jZQ==',
@@ -30,12 +31,13 @@ $req = Protocol::WebSocket::Request->new_from_psgi(
     }
 );
 $req->parse($io);
-is $req->resource_name => '/chat?foo=bar';
-is $req->subprotocol   => 'chat, superchat';
-is $req->upgrade       => 'websocket';
-is $req->connection    => 'Upgrade';
-is $req->host          => 'server.example.com';
-is $req->origin        => 'http://example.com';
-is $req->key           => 'dGhlIHNhbXBsZSBub25jZQ==';
+is $req->resource_name      => '/chat?foo=bar';
+is $req->subprotocol        => 'chat, superchat';
+is $req->upgrade            => 'websocket';
+is $req->connection         => 'Upgrade';
+is $req->host               => 'server.example.com';
+is $req->cookies->to_string => 'foo=bar';
+is $req->origin             => 'http://example.com';
+is $req->key                => 'dGhlIHNhbXBsZSBub25jZQ==';
 ok $req->is_done;
 is $req->version => 'draft-ietf-hybi-17';


### PR DESCRIPTION
I needed a way to send cookies to my server using Protocol::WebSocket::Request, but, for my disappointment, it wasn't implemented. This patch implements a way to generate a request with a Cookie header.
