### PR TITLE
Bug fix: Frame could not mask the payload correctly if the payload (buffer attribute) looks like number.

### DIFF
--- a/lib/Protocol/WebSocket/Frame.pm
+++ b/lib/Protocol/WebSocket/Frame.pm
@@ -307,7 +307,7 @@ sub _mask {
 
     $mask = $mask x (int(length($payload) / 4) + 1);
     $mask = substr($mask, 0, length($payload));
-    $payload ^= $mask;
+    $payload = "$payload" ^ $mask;
 
     return $payload;
 }


### PR DESCRIPTION
This was because if the payload looks like a number, the ^ operator in _mask() method is recognized as numeric XOR, not as bitstring XOR.
I Fixed the bug by explicitly stringifying the $payload.

This bug blocks the tests I'm writing for AnyEvent::WebSocket::Client, so I hope this patch will be released on CPAN soon.
