### PR TITLE
Rewrite Digest::SHA1 to Digest::SHA.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
 requires 'Carp'         => 0;
 requires 'Digest::MD5'  => 0;
-requires 'Digest::SHA1' => 0;
+requires 'Digest::SHA'  => 0;
 requires 'Scalar::Util' => 0;

--- a/lib/Protocol/WebSocket/Response.pm
+++ b/lib/Protocol/WebSocket/Response.pm
@@ -7,7 +7,7 @@ use base 'Protocol::WebSocket::Message';
 
 require Carp;
 use MIME::Base64 ();
-use Digest::SHA1 ();
+use Digest::SHA ();
 
 use Protocol::WebSocket::URL;
 use Protocol::WebSocket::Cookie::Response;
@@ -91,7 +91,7 @@ sub headers {
 
         my $key = $self->key;
         $key .= '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'; # WTF
-        $key = Digest::SHA1::sha1($key);
+        $key = Digest::SHA::sha1($key);
         $key = MIME::Base64::encode_base64($key);
         $key =~ s{\s+}{}g;
 


### PR DESCRIPTION
I mean, that is time to remove Digest::SHA1 dependency.
Is obsolete in Debian (see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=594273)
When i see to releases of Digest::SHA1 and Digest::SHA is Digest::SHA1 obsolete.
