### PR TITLE
do not modify headers when converting request to string

### DIFF
--- a/lib/Protocol/WebSocket/Request.pm
+++ b/lib/Protocol/WebSocket/Request.pm
@@ -194,8 +194,8 @@ sub to_string {
     else {
         Carp::croak('Version ' . $self->version . ' is not supported');
     }
-
-    while (my ($key, $value) = splice @{$self->{headers}}, 0, 2) {
+    my @headers = @{$self->{headers}};
+    while (my ($key, $value) = splice @headers, 0, 2) {
         $key =~ s{[\x0d\x0a]}{}gsm;
         $value =~ s{[\x0d\x0a]}{}gsm;
 

--- a/t/draft-ietf-hybi-17/request.t
+++ b/t/draft-ietf-hybi-17/request.t
@@ -111,6 +111,16 @@ subtest 'add custom headers' => sub {
       . "Sec-WebSocket-Version: 13\x0d\x0a"
       . "X-Foo: bar\x0d\x0a"
       . "\x0d\x0a";
+
+    is $req->to_string => "GET /chat HTTP/1.1\x0d\x0a"
+      . "Upgrade: WebSocket\x0d\x0a"
+      . "Connection: Upgrade\x0d\x0a"
+      . "Host: server.example.com\x0d\x0a"
+      . "Origin: http://example.com\x0d\x0a"
+      . "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\x0d\x0a"
+      . "Sec-WebSocket-Version: 13\x0d\x0a"
+      . "X-Foo: bar\x0d\x0a"
+      . "\x0d\x0a";
 };
 
 done_testing;


### PR DESCRIPTION
I noticed that when I printed the request out twice I got different results.  Please consider this patch which will make sure that the header attribute is not modified on the request object.  I have also included a test which demonstrates the bug.