### PR TITLE
Optionally turn off max_payload_size

### DIFF
--- a/lib/Protocol/WebSocket/Client.pm
+++ b/lib/Protocol/WebSocket/Client.pm
@@ -32,9 +32,9 @@ sub new {
       Protocol::WebSocket::Handshake::Client->new(url => $self->{url});
 
     my %frame_buffer_params = (
-        max_fragments_amount => $params{max_fragments_amount},
-        max_payload_size     => $params{max_payload_size}
+        max_fragments_amount => $params{max_fragments_amount}
     );
+    $frame_buffer_params{max_payload_size} = $params{max_payload_size} if exists $params{max_payload_size};
 
     $self->{frame_buffer} = $self->_build_frame(%frame_buffer_params);
 

--- a/t/client.t
+++ b/t/client.t
@@ -81,6 +81,15 @@ subtest 'call on_write on write' => sub {
     isnt $written, '';
 };
 
+subtest 'max_payload_size passed to frame buffer' => sub {
+
+    is(Protocol::WebSocket::Client->new(url => 'ws://localhost:8080')->{frame_buffer}->max_payload_size, 65536, "default");
+    is(Protocol::WebSocket::Client->new(url => 'ws://localhost:8080', max_payload_size => 22)->{frame_buffer}->max_payload_size, 22, "set to 22");
+    is(Protocol::WebSocket::Client->new(url => 'ws://localhost:8080', max_payload_size => 0)->{frame_buffer}->max_payload_size, 0, "set to 0");
+    is(Protocol::WebSocket::Client->new(url => 'ws://localhost:8080', max_payload_size => undef)->{frame_buffer}->max_payload_size, undef, "set to undef");
+
+};
+
 sub _recv_server_handshake {
     my ($client) = @_;
 

--- a/t/frame.t
+++ b/t/frame.t
@@ -1,0 +1,66 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 11;
+
+use_ok 'Protocol::WebSocket::Frame';
+
+is( Protocol::WebSocket::Frame->new->max_payload_size, 65536, 'default max_payload_size' );
+is( Protocol::WebSocket::Frame->new(max_payload_size => 22)->max_payload_size, 22, 'override max_payload_size' );
+is( Protocol::WebSocket::Frame->new(max_payload_size => 0)->max_payload_size, 0, 'turn off max_payload_size' );
+is( Protocol::WebSocket::Frame->new(max_payload_size => undef)->max_payload_size, undef, 'turn off max_payload_size' );
+
+subtest 'payload too large (to_bytes)' => sub {
+
+    my $frame = Protocol::WebSocket::Frame->new(buffer => 'x' x 65537);
+    eval { $frame->to_bytes };
+    like $@, qr/Payload is too big\. Send shorter messages or increase max_payload_size/;
+
+};
+
+subtest 'payload larger than 65536, but under max (to_bytes)' => sub {
+
+    my $frame = Protocol::WebSocket::Frame->new(buffer => 'x' x 65537, max_payload_size => 65537);
+    eval { $frame->to_bytes };
+    is $@, '';
+
+};
+
+subtest 'turn off payload size checking (to_bytes)' => sub {
+
+    my $frame = Protocol::WebSocket::Frame->new(buffer => 'x' x 65537, max_payload_size => 0);
+    eval { $frame->to_bytes };
+    is $@, '';
+
+};
+
+my $large_frame = Protocol::WebSocket::Frame->new(buffer => 'x' x 65537, max_payload_size => 0);
+
+subtest 'payload too large (next_bytes)' => sub {
+
+    my $frame = Protocol::WebSocket::Frame->new;
+    $frame->append($large_frame->to_bytes);
+    eval { $frame->next_bytes };
+    like $@, qr/Payload is too big\. Deny big message/;
+
+};
+
+subtest 'payload larger than 65536, but under max (next_bytes)' => sub {
+
+    my $frame = Protocol::WebSocket::Frame->new( max_payload_size => 65537);
+    $frame->append($large_frame->to_bytes);
+    eval { $frame->next_bytes };
+    is $@, '';
+
+};
+
+subtest 'turn off payload size checking (next_bytes)' => sub {
+
+    my $frame = Protocol::WebSocket::Frame->new( max_payload_size => 0);
+    $frame->append($large_frame->to_bytes);
+    eval { $frame->next_bytes };
+    is $@, '';
+
+};


### PR DESCRIPTION
by setting it to either 0 or undef.  As requested here:

https://github.com/vti/protocol-websocket/issues/43

And intended for use as a response to:

https://github.com/debug-ito/AnyEvent-WebSocket-Server/issues/3