### PR TITLE
draft-ietf-hybi-17 uses origin header, not sec-websocket-origin

### DIFF
--- a/lib/Protocol/WebSocket/Request.pm
+++ b/lib/Protocol/WebSocket/Request.pm
@@ -64,7 +64,7 @@ sub new_from_psgi {
         $fields->{'sec-websocket-key2'} = $env->{HTTP_SEC_WEBSOCKET_KEY2};
     }
 
-    if ($version eq 'draft-ietf-hybi-10' || $version eq 'draft-ietf-hybi-17') {
+    if ($version eq 'draft-ietf-hybi-10') {
         $fields->{'sec-websocket-origin'} = $env->{HTTP_SEC_WEBSOCKET_ORIGIN};
     }
     else {


### PR DESCRIPTION
draft-ietf-hybi-17 sends an Origin header, not Sec-WebSocket-Origin:
https://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-17#section-1.3

draft-ietf-hybi-10 does send Sec-WebSocket-Origin as indicated in the original code:
https://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-10#section-11.8