### PR TITLE
Include actual response in error text of first response line

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for perl module Protocol::WebSocket
 
 {{$NEXT}}
 
+ - The "Wrong response line" error now includes the actual response line
+
 0.24 2018-01-13T09:59:07Z
 
  -  draft-ietf-hybi-17 uses origin header, not sec-websocket-origin (Eric Wastl)

--- a/lib/Protocol/WebSocket/Response.pm
+++ b/lib/Protocol/WebSocket/Response.pm
@@ -150,7 +150,7 @@ sub _parse_first_line {
         my $vis = $line;
         if( length( $vis ) > 80 ) {
             substr( $vis, 77 )= '...';
-        };
+        }
         $self->error('Wrong response line. Got [[' . $vis . "]], expected [[HTTP/1.1 $status ]]");
         return;
     }

--- a/lib/Protocol/WebSocket/Response.pm
+++ b/lib/Protocol/WebSocket/Response.pm
@@ -147,7 +147,11 @@ sub _parse_first_line {
 
     my $status = $self->status;
     unless ($line =~ m{^HTTP/1\.1 $status }) {
-        $self->error('Wrong response line. Got [[' . $line . "]], expected [[HTTP/1.1 $status ]]");
+        my $vis = $line;
+        if( length( $vis ) > 80 ) {
+            substr( $vis, 77 )= '...';
+        };
+        $self->error('Wrong response line. Got [[' . $vis . "]], expected [[HTTP/1.1 $status ]]");
         return;
     }
 

--- a/lib/Protocol/WebSocket/Response.pm
+++ b/lib/Protocol/WebSocket/Response.pm
@@ -147,7 +147,7 @@ sub _parse_first_line {
 
     my $status = $self->status;
     unless ($line =~ m{^HTTP/1\.1 $status }) {
-        $self->error('Wrong response line');
+        $self->error('Wrong response line. Got [[' . $line . "]], expected [[HTTP/1.1 $status ]]");
         return;
     }
 

--- a/t/response_common.t
+++ b/t/response_common.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 6;
+use Test::More tests => 8;
 
 use_ok 'Protocol::WebSocket::Response';
 
@@ -13,6 +13,11 @@ $res = Protocol::WebSocket::Response->new;
 $res->parse("foo\x0d\x0a");
 ok $res->is_state('error');
 is $res->error => 'Wrong response line. Got [[foo]], expected [[HTTP/1.1 101 ]]';
+
+$res = Protocol::WebSocket::Response->new;
+$res->parse(("1234567890" x 10) . "\x0d\x0a");
+ok $res->is_state('error');
+is $res->error => 'Wrong response line. Got [[12345678901234567890123456789012345678901234567890123456789012345678901234567...]], expected [[HTTP/1.1 101 ]]';
 
 local $Protocol::WebSocket::Message::MAX_MESSAGE_SIZE = 1024;
 

--- a/t/response_common.t
+++ b/t/response_common.t
@@ -12,7 +12,7 @@ my $res;
 $res = Protocol::WebSocket::Response->new;
 $res->parse("foo\x0d\x0a");
 ok $res->is_state('error');
-is $res->error => 'Wrong response line';
+is $res->error => 'Wrong response line. Got [[foo]], expected [[HTTP/1.1 101 ]]';
 
 local $Protocol::WebSocket::Message::MAX_MESSAGE_SIZE = 1024;
 


### PR DESCRIPTION
Thank you for writing and maintaining Protocol::WebSocket!

I am debugging spurious errors in a WebSocket server ( Chrome as server ) and for this, it was beneficial to have the actual response included with the error message.

If you think that I should change the API or maybe change other stuff, please tell me!