### PR TITLE
Update draft-ietf-hybi-00 tests to include the error text in response line

### DIFF
--- a/t/draft-ietf-hybi-00/client-ssl.t
+++ b/t/draft-ietf-hybi-00/client-ssl.t
@@ -71,4 +71,5 @@ ok !$h->error;
 
 $h = Protocol::WebSocket::Handshake::Client->new;
 ok !$h->parse("HTTP/1.0 foo bar\x0d\x0a");
-is $h->error => 'Wrong response line';
+is $h->error => 'Wrong response line. Got [[HTTP/1.0 foo bar]], '
+  . 'expected [[HTTP/1.1 101 ]]';

--- a/t/draft-ietf-hybi-00/client.t
+++ b/t/draft-ietf-hybi-00/client.t
@@ -71,4 +71,5 @@ ok !$h->error;
 
 $h = Protocol::WebSocket::Handshake::Client->new;
 ok !$h->parse("HTTP/1.0 foo bar\x0d\x0a");
-is $h->error => 'Wrong response line';
+is $h->error => 'Wrong response line. Got [[HTTP/1.0 foo bar]], '
+  . 'expected [[HTTP/1.1 101 ]]';


### PR DESCRIPTION
Commit 64157e25b52ee8348f13bee44574bb41af628341 broke draft-ietf-hybi-00 tests, which were not updated in order to reflect the new response line. This commit fixes this.