### PR TITLE
Some fixes for UTF-8 decode, and Close frames

### DIFF
--- a/lib/Protocol/WebSocket/Frame.pm
+++ b/lib/Protocol/WebSocket/Frame.pm
@@ -84,7 +84,7 @@ sub next {
     my $bytes = $self->next_bytes;
     return unless defined $bytes;
 
-    if ($self->is_text) {
+    if ($self->{version} eq 'draft-ietf-hybi-00' || $self->is_text) {
       return Encode::decode('UTF-8', $bytes);
     } else {
       return $bytes;

--- a/lib/Protocol/WebSocket/Frame.pm
+++ b/lib/Protocol/WebSocket/Frame.pm
@@ -84,7 +84,11 @@ sub next {
     my $bytes = $self->next_bytes;
     return unless defined $bytes;
 
-    return Encode::decode('UTF-8', $bytes);
+    if ($self->is_text) {
+      return Encode::decode('UTF-8', $bytes);
+    } else {
+      return $bytes;
+    }
 }
 
 sub fin {


### PR DESCRIPTION
Some testing while building a client against a live service turned up a few issues with this library.  This commit fixes two problems:

- Close messages may have a payload containing a 2-byte uint16 error number, and then a UTF-8 message in the payload.  These were not handled on receive or send.

- Frame class *always* converted payload to/from UTF-8, but this is really only correct for Text frames.  Control frames and Binary frames should not be converted.

This patch adds correct handling of Close frames, and changes the Frame class to only encode/decode UTF-8 for Text frames.